### PR TITLE
Fix expo response details model

### DIFF
--- a/sdk/push.go
+++ b/sdk/push.go
@@ -90,10 +90,10 @@ const ErrorMessageRateExceeded = "MessageRateExceeded"
 //      'message': '"adsf" is not a registered push notification recipient'}
 type PushResponse struct {
 	PushMessage PushMessage
-	ID			string			  `json:"id"`
-	Status      string            `json:"status"`
-	Message     string            `json:"message"`
-	Details     map[string]string `json:"details"`
+	ID          string                 `json:"id"`
+	Status      string                 `json:"status"`
+	Message     string                 `json:"message"`
+	Details     map[string]interface{} `json:"details"`
 }
 
 func (r *PushResponse) isSuccess() bool {


### PR DESCRIPTION
Fix the issue when publishing notifications to expo the reading of the
response fails with `json: cannot unmarshal object into Go struct field
PushResponse.data.details of type string.`

mirrors https://github.com/oliveroneill/exponent-server-sdk-golang/pull/25
fixes https://github.com/oliveroneill/exponent-server-sdk-golang/issues/13